### PR TITLE
Ability to pass an existing connection to build ElasticSearchService

### DIFF
--- a/mahuta-indexer-elasticsearch/src/main/java/net/consensys/mahuta/core/indexer/elasticsearch/ElasticSearchService.java
+++ b/mahuta-indexer-elasticsearch/src/main/java/net/consensys/mahuta/core/indexer/elasticsearch/ElasticSearchService.java
@@ -103,6 +103,13 @@ public class ElasticSearchService implements IndexingService {
         }
     }
 
+    public static ElasticSearchService connect(TransportClient transportClient) {
+
+        log.info("Connected to ElasticSearch [via transportClient] : {}", transportClient.listedNodes().toString());
+
+        return new ElasticSearchService(ElasticSearchSettings.of(), transportClient);
+    }
+
     public ElasticSearchService configureIndexNullValue(boolean indexNullValue) {
         this.settings.setIndexNullValue(indexNullValue);
         return this;

--- a/mahuta-indexer-elasticsearch/src/main/java/net/consensys/mahuta/core/indexer/elasticsearch/ElasticSearchSettings.java
+++ b/mahuta-indexer-elasticsearch/src/main/java/net/consensys/mahuta/core/indexer/elasticsearch/ElasticSearchSettings.java
@@ -13,6 +13,10 @@ public class ElasticSearchSettings {
     private @Setter @Getter Integer port = DEFAULT_PORT;
     private @Setter @Getter String clusterName;
     private @Setter @Getter boolean indexNullValue = DEFAULT_INDEX_NULL_VALUES;
+
+    public static ElasticSearchSettings of() {
+        return new ElasticSearchSettings();
+    }
     
     public static ElasticSearchSettings of(String host, Integer port, String clusterName) {
         ElasticSearchSettings s = new ElasticSearchSettings();


### PR DESCRIPTION
rather than host/port/clusterName